### PR TITLE
Add gres option in SBATCH specs to run jupyternotebooks on gpus

### DIFF
--- a/slurm_jupyter/__init__.py
+++ b/slurm_jupyter/__init__.py
@@ -365,11 +365,11 @@ def open_browser(spec, force_chrome=False):
         spec (dict): Parameter specification.
     """
     if not spec['url']:
-        url = 'https://localhost:{port}'.format(**spec)
+        spec['url'] = 'https://localhost:{port}'.format(**spec)
     if platform.platform().startswith('Darwin') or platform.platform().startswith('macOS-'):
         chrome_path = 'open -a /Applications/Google\ Chrome.app %s'
         if force_chrome and os.path.exists('/Applications/Google Chrome.app'):
-            webbrowser.get(chrome_path).open(url, new=2)
+            webbrowser.get(chrome_path).open(spec['url'], new=2)
         else:
             webbrowser.open(spec['url'], new=2)
     elif platform.platform().startswith('Windows'):
@@ -604,6 +604,10 @@ def slurm_jupyter():
         days, (hours, mins, secs) = tup[0], tup[1].split(':')
     end_time = int(time.time()) + int(days) * 86400 + int(hours) * 3600 + int(mins) * 60 + int(secs)
 
+    spec['gres'] = ''
+    if args.queue == 'gpu':
+        spec['gres'] = '#SBATCH --gres=gpu:1'
+        
     if args.total_memory:
         spec['memory_spec'] = '#SBATCH --mem {}'.format(int(str_to_mb(args.total_memory)))
     else:

--- a/slurm_jupyter/__init__.py
+++ b/slurm_jupyter/__init__.py
@@ -365,11 +365,11 @@ def open_browser(spec, force_chrome=False):
         spec (dict): Parameter specification.
     """
     if not spec['url']:
-        spec['url'] = 'https://localhost:{port}'.format(**spec)
+        url = 'https://localhost:{port}'.format(**spec)
     if platform.platform().startswith('Darwin') or platform.platform().startswith('macOS-'):
         chrome_path = 'open -a /Applications/Google\ Chrome.app %s'
         if force_chrome and os.path.exists('/Applications/Google Chrome.app'):
-            webbrowser.get(chrome_path).open(spec['url'], new=2)
+            webbrowser.get(chrome_path).open(url, new=2)
         else:
             webbrowser.open(spec['url'], new=2)
     elif platform.platform().startswith('Windows'):

--- a/slurm_jupyter/templates.py
+++ b/slurm_jupyter/templates.py
@@ -4,6 +4,7 @@
 # shell script for running a batch job
 slurm_batch_script =  """#!/bin/sh
 #SBATCH -p {queue}
+{gres}
 {memory_spec}
 #SBATCH -n {nr_nodes}
 #SBATCH -c {nr_cores}
@@ -21,6 +22,7 @@ slurm_batch_script =  """#!/bin/sh
 # shell script for running the jupyter server
 slurm_server_script =  """#!/bin/sh
 #SBATCH -p {queue}
+{gres}
 {memory_spec}
 #SBATCH -n {nr_nodes}
 #SBATCH -c {nr_cores}


### PR DESCRIPTION
I added the spec `gres` in the SBATCH specs such that jupyternotebooks can be run on GPUs, as described in #2. This only happens when the user sets the option `queue` to gpu. 

Potentially, `gres` can be set up to the number of GPU nodes the cluster has (4 in the case of GenomeDK). For example, for 2 gpu nodes the SBATCH spec should be defined as `'#SBATCH --gres=gpu:2'`. This could be another user-defined option, but I don't think anyone wants to run jupiternotebooks on 4 GPUs... So, I don't think this needs to be done unless someone requests it. 

Additionally, I modified the variable `url` to `spec['url']` in the function `open_browser()` since it was creating a bug when I run the script on my local computer: the function was trying to open the URL `url` on Chrome, but such variable didn't exist since it is actually `spec['url']`. 